### PR TITLE
feat: support json sensor data

### DIFF
--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -57,13 +57,21 @@ const GraphPage = () => {
         if (data.success) {
           let allData = [];
           data.files.forEach(fileContent => {
-            const rows = fileContent.split('\n').slice(1); // Remove header row
-            rows.forEach(row => {
-              const [timestamp, value] = row.split(',');
-              if (timestamp && value) {
-                allData.push({ timestamp: new Date(parseFloat(timestamp)), value: parseFloat(value) });
+            try {
+              const json = JSON.parse(fileContent);
+              if (Array.isArray(json.data)) {
+                json.data.forEach(point => {
+                  if (point.timestamp !== undefined && point.value !== undefined) {
+                    allData.push({
+                      timestamp: new Date(point.timestamp),
+                      value: parseFloat(point.value),
+                    });
+                  }
+                });
               }
-            });
+            } catch (err) {
+              console.error('Invalid JSON in data file:', err);
+            }
           });
 
           allData.sort((a, b) => a.timestamp - b.timestamp);


### PR DESCRIPTION
## Summary
- generate sine wave data as JSON in send-dummy-data.sh
- parse uploaded JSON sensor data on the graph page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a85d7b683c83279f7e61edf31f5686