### PR TITLE
Handle JSON-only data files

### DIFF
--- a/send-dummy-data.sh
+++ b/send-dummy-data.sh
@@ -23,32 +23,28 @@ if ! curl -s --head "$STATUS_URL" | head -n 1 | grep "200 OK" >/dev/null; then
   exit 1
 fi
 
-# === Generate Sine Wave CSV Data ===
+# === Generate Sine Wave JSON Data ===
 DURATION=1000 # milliseconds
 INTERVAL=10   # 10 ms between points
 AMPLITUDE=2000
 OFFSET=2047
 FREQUENCY=$(awk -v min=1 -v max=10 'BEGIN{srand(); print int(min+rand()*(max-min+1))}')
 
-# CSV with metadata header
-CSV_PAYLOAD="# Fault Type: $FAULT_TYPE
-# Fault Location: $FAULT_LOCATION
-# Date: $CURRENT_DATE
-# Time: $CURRENT_TIME
-n,value"
-
-# Generate sine wave values
-n=1
+BASE_TS=$(( $(date +%s) * 1000 ))
+# Build JSON payload via string concatenation
+JSON_PAYLOAD="{\"faultType\":\"$FAULT_TYPE\",\"faultLocation\":\"$FAULT_LOCATION\"," 
+JSON_PAYLOAD+="\"date\":\"$CURRENT_DATE\",\"time\":\"$CURRENT_TIME\",\"data\":["
 for ((i = 0; i <= $DURATION; i += $INTERVAL)); do
   VALUE=$(awk -v amp=$AMPLITUDE -v freq=$FREQUENCY -v t_ms=$i -v offset=$OFFSET \
     'BEGIN{print int(amp * sin(2 * 3.14159265359 * freq * (t_ms / 1000)) + offset)}')
-  CSV_PAYLOAD+="
-$n,$VALUE"
-  ((n++))
+  TIMESTAMP=$(( BASE_TS + i ))
+  JSON_PAYLOAD+="{\"timestamp\":$TIMESTAMP,\"value\":$VALUE},"
 done
+JSON_PAYLOAD=${JSON_PAYLOAD%,}
+JSON_PAYLOAD+"]}"
 
 # === Filename includes metadata ===
-FILENAME="fault_${FAULT_TYPE}_${FAULT_LOCATION}_${CURRENT_DATE//-/}_${CURRENT_TIME//:/}.csv"
+FILENAME="fault_${FAULT_TYPE}_${FAULT_LOCATION}_${CURRENT_DATE//-/}_${CURRENT_TIME//:/}.json"
 
 # === Display Info ===
 echo "---------------------------------"
@@ -59,11 +55,12 @@ echo "Frequency: ${FREQUENCY} Hz"
 echo "Filename: $FILENAME"
 echo "---------------------------------"
 
-# === Upload CSV ===
+# === Upload JSON ===
 curl -s -X POST \
-  -F "file=@-;type=text/csv;filename=$FILENAME" \
+  -F "file=@-;type=application/json;filename=$FILENAME" \
   "$API_URL" <<EOF
-$CSV_PAYLOAD
+$JSON_PAYLOAD
 EOF
 
 echo -e "\n✅ Successfully sent data to $API_URL"
+

--- a/src/app/api/data/route.js
+++ b/src/app/api/data/route.js
@@ -10,10 +10,11 @@ export async function GET(request) {
 
   try {
     if (filename) {
-      // If a filename is provided, read and return that file's content
+      // If a filename is provided, read and return that file's JSON content
       const filePath = join(dataDir, filename);
       const fileContent = await readFile(filePath, 'utf-8');
-      return NextResponse.json({ success: true, files: [fileContent] });
+      const json = JSON.parse(fileContent);
+      return NextResponse.json({ success: true, file: json });
     } else {
       // Otherwise, return the list of JSON filenames only
       const filenames = (await readdir(dataDir)).filter(name => name.endsWith('.json'));

--- a/src/app/api/data/route.js
+++ b/src/app/api/data/route.js
@@ -15,8 +15,8 @@ export async function GET(request) {
       const fileContent = await readFile(filePath, 'utf-8');
       return NextResponse.json({ success: true, files: [fileContent] });
     } else {
-      // Otherwise, return the list of filenames
-      const filenames = await readdir(dataDir);
+      // Otherwise, return the list of JSON filenames only
+      const filenames = (await readdir(dataDir)).filter(name => name.endsWith('.json'));
       return NextResponse.json({ success: true, filenames });
     }
   } catch (error) {

--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -54,27 +54,15 @@ const GraphPage = () => {
         const res = await fetch(`/api/data?file=${selectedFile}`);
         const data = await res.json();
 
-        if (data.success) {
-          let allData = [];
-          data.files.forEach(fileContent => {
-            try {
-              const json = JSON.parse(fileContent);
-              if (Array.isArray(json.data)) {
-                json.data.forEach(point => {
-                  if (point.timestamp !== undefined && point.value !== undefined) {
-                    allData.push({
-                      timestamp: new Date(point.timestamp),
-                      value: parseFloat(point.value),
-                    });
-                  }
-                });
-              }
-            } catch (err) {
-              console.error('Invalid JSON in data file:', err);
-            }
-          });
-
-          allData.sort((a, b) => a.timestamp - b.timestamp);
+        if (data.success && data.file) {
+          const points = Array.isArray(data.file.data) ? data.file.data : [];
+          const allData = points
+            .filter(p => p.timestamp !== undefined && p.value !== undefined)
+            .map(p => ({
+              timestamp: new Date(p.timestamp),
+              value: parseFloat(p.value),
+            }))
+            .sort((a, b) => a.timestamp - b.timestamp);
 
           const chartJsData = {
             labels: allData.map(d => d.timestamp.toLocaleTimeString()),

--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -57,13 +57,21 @@ const GraphPage = () => {
         if (data.success) {
           let allData = [];
           data.files.forEach(fileContent => {
-            const rows = fileContent.split('\n').slice(1); // Remove header row
-            rows.forEach(row => {
-              const [timestamp, value] = row.split(',');
-              if (timestamp && value) {
-                allData.push({ timestamp: new Date(parseFloat(timestamp)), value: parseFloat(value) });
+            try {
+              const json = JSON.parse(fileContent);
+              if (Array.isArray(json.data)) {
+                json.data.forEach(point => {
+                  if (point.timestamp !== undefined && point.value !== undefined) {
+                    allData.push({
+                      timestamp: new Date(point.timestamp),
+                      value: parseFloat(point.value),
+                    });
+                  }
+                });
               }
-            });
+            } catch (err) {
+              console.error('Invalid JSON in data file:', err);
+            }
           });
 
           allData.sort((a, b) => a.timestamp - b.timestamp);


### PR DESCRIPTION
## Summary
- Generate JSON payloads without stray newlines in `send-dummy-data.sh`
- Filter `/api/data` listings to only return `.json` files

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a85d7b683c83279f7e61edf31f5686