### PR TITLE
feat: add firmware upload page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# firmware uploads
+/firmware/*
+!/firmware/.gitkeep

--- a/src/app/api/firmware/route.js
+++ b/src/app/api/firmware/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+
+export async function POST(request) {
+  const formData = await request.formData();
+  const file = formData.get("file");
+
+  if (!file) {
+    return NextResponse.json(
+      { success: false, error: "No file uploaded" },
+      { status: 400 }
+    );
+  }
+
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+  const firmwareDir = join(process.cwd(), "firmware");
+  await mkdir(firmwareDir, { recursive: true });
+  await writeFile(join(firmwareDir, file.name), buffer);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/firmware/page.jsx
+++ b/src/app/firmware/page.jsx
@@ -33,13 +33,13 @@ export default function FirmwarePage() {
   };
 
   return (
-    <div className="p-4">
+    <div className="flex flex-col items-center justify-center min-h-screen">
       <h1 className="text-2xl mb-4">Upload Firmware</h1>
       <div
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onClick={() => document.getElementById("fileInput").click()}
-        className="border-2 border-dashed border-gray-400 p-8 text-center cursor-pointer"
+        className="border-2 border-dashed border-gray-400 w-[200px] h-[100px] flex items-center justify-center cursor-pointer"
       >
         Drag and drop a firmware file here or click to select
       </div>

--- a/src/app/firmware/page.jsx
+++ b/src/app/firmware/page.jsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+
+export default function FirmwarePage() {
+  const [message, setMessage] = useState("");
+
+  const uploadFile = async (file) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const res = await fetch("/api/firmware", {
+      method: "POST",
+      body: formData,
+    });
+    if (res.ok) {
+      setMessage("Upload successful");
+    } else {
+      setMessage("Upload failed");
+    }
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) uploadFile(file);
+  };
+
+  const handleDragOver = (e) => e.preventDefault();
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (file) uploadFile(file);
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl mb-4">Upload Firmware</h1>
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onClick={() => document.getElementById("fileInput").click()}
+        className="border-2 border-dashed border-gray-400 p-8 text-center cursor-pointer"
+      >
+        Drag and drop a firmware file here or click to select
+      </div>
+      <input
+        id="fileInput"
+        type="file"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -10,6 +10,9 @@ export default function Navbar() {
         <li>
           <Link href="/graph" className="hover:underline">Graph</Link>
         </li>
+        <li>
+          <Link href="/firmware" className="hover:underline">Firmware</Link>
+        </li>
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Summary
- add API route for firmware uploads
- create firmware upload page with drag-and-drop
- update navbar and gitignore for firmware storage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae8ee76cf08327a483b7fa5e4a825e