### PR TITLE
Improve responsive layout

### DIFF
--- a/src/app/firmware/page.jsx
+++ b/src/app/firmware/page.jsx
@@ -33,13 +33,13 @@ export default function FirmwarePage() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
+    <div className="flex flex-col items-center justify-center min-h-screen p-4">
       <h1 className="text-2xl mb-4">Upload Firmware</h1>
       <div
         onDrop={handleDrop}
         onDragOver={handleDragOver}
         onClick={() => document.getElementById("fileInput").click()}
-        className="border-2 border-dashed border-gray-400 w-[600px] h-[200px] flex items-center justify-center cursor-pointer"
+        className="border-2 border-dashed border-gray-400 w-full max-w-xl h-48 flex items-center justify-center cursor-pointer text-center"
       >
         Drag and drop a firmware file here or click to select
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,12 @@ body {
   padding: 2rem;
 }
 
+@media (max-width: 640px) {
+  .container {
+    padding: 1rem;
+  }
+}
+
 .title {
   text-align: center;
   margin-bottom: 2rem;

--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -126,9 +126,13 @@ const GraphPage = () => {
 
   return (
     <div className="container">
-      <h1 className="title">Sensor Data</h1>
-      <div className="dropdown-container">
-        <select style= {{backgroundColor :'black', color : 'white'}} onChange={(e) => setSelectedFile(e.target.value)} value={selectedFile}>
+      <h1 className="title text-xl sm:text-2xl">Sensor Data</h1>
+      <div className="dropdown-container flex justify-center">
+        <select
+          className="bg-black text-white p-2 rounded w-full max-w-xs"
+          onChange={(e) => setSelectedFile(e.target.value)}
+          value={selectedFile}
+        >
           {filenames.map(file => (
             <option key={file} value={file}>{file}</option>
           ))}
@@ -148,7 +152,7 @@ const GraphPage = () => {
         </label>
       </div>
       {voltageData && currentData ? (
-        <div className="flex w-full max-w-5xl mx-auto">
+        <div className="flex flex-col lg:flex-row w-full max-w-5xl mx-auto">
           <div className="flex flex-col items-center space-y-8 flex-grow">
             <div className="w-full max-w-3xl">
               <h2 className="text-center mb-2">Voltage</h2>
@@ -184,7 +188,7 @@ const GraphPage = () => {
                   </label>
                 ))}
               </div>
-              <div className="grid grid-cols-3 gap-2 text-xs mt-2 text-center">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs mt-2 text-center">
                 {voltageData.datasets.map(ds => (
                   <div key={ds.key}>
                     {ds.label} Min: {ds.min.toFixed(2)} Max: {ds.max.toFixed(2)}
@@ -226,7 +230,7 @@ const GraphPage = () => {
                   </label>
                 ))}
               </div>
-              <div className="grid grid-cols-3 gap-2 text-xs mt-2 text-center">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs mt-2 text-center">
                 {currentData.datasets.map(ds => (
                   <div key={ds.key}>
                     {ds.label} Min: {ds.min.toFixed(2)} Max: {ds.max.toFixed(2)}
@@ -235,7 +239,7 @@ const GraphPage = () => {
               </div>
             </div>
           </div>
-          <div className="w-64 ml-4">
+          <div className="w-full lg:w-64 lg:ml-4 mt-8 lg:mt-0">
             <h2 className="mb-2 font-semibold">Fault Info</h2>
             <p>
               <span className="font-medium">Fault Type:</span>{' '}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -2,13 +2,13 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-8">
-      <h1 className="text-4xl font-bold mb-8 text-center">
+    <main className="flex flex-col items-center justify-center min-h-screen p-4 sm:p-8">
+      <h1 className="text-3xl sm:text-4xl font-bold mb-8 text-center">
         Digital Fault Recorder
       </h1>
       <Link
         href="/graph"
-        className="bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700"
+        className="bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700 w-full sm:w-auto text-center"
       >
         Go to Graph
       </Link>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function Navbar() {
   return (
     <nav className="bg-gray-800 text-white p-4">
-      <ul className="flex gap-4">
+      <ul className="flex flex-col sm:flex-row gap-2 sm:gap-4 text-center sm:text-left">
         <li>
           <Link href="/" className="hover:underline">Home</Link>
         </li>


### PR DESCRIPTION
## Summary
- Make navigation menu stack on small screens
- Adapt home and firmware pages for mobile-friendly spacing
- Refactor graph page with responsive layout and controls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae946535b083279b84151d5aac21e5