### PR TITLE
refactor: refresh UI styling

### DIFF
--- a/src/app/firmware/page.jsx
+++ b/src/app/firmware/page.jsx
@@ -33,14 +33,14 @@ export default function FirmwarePage() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center flex-1 p-4">
-      <div className="w-full max-w-xl bg-white/80 backdrop-blur-sm rounded-xl shadow-lg p-6 text-center">
+    <div className="flex flex-col items-center justify-center flex-1 p-4 text-gray-100">
+      <div className="w-full max-w-xl bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-lg p-6 text-center">
         <h1 className="text-2xl mb-4 font-semibold">Upload Firmware</h1>
         <div
           onDrop={handleDrop}
           onDragOver={handleDragOver}
           onClick={() => document.getElementById("fileInput").click()}
-          className="border-2 border-dashed border-gray-400 w-full h-48 flex items-center justify-center cursor-pointer rounded-lg bg-gray-50 hover:bg-gray-100 transition text-center"
+          className="border-2 border-dashed border-gray-500 w-full h-48 flex items-center justify-center cursor-pointer rounded-lg bg-gray-700 hover:bg-gray-600 transition text-center"
         >
           Drag and drop a firmware file here or click to select
         </div>

--- a/src/app/firmware/page.jsx
+++ b/src/app/firmware/page.jsx
@@ -33,23 +33,25 @@ export default function FirmwarePage() {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-4">
-      <h1 className="text-2xl mb-4">Upload Firmware</h1>
-      <div
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-        onClick={() => document.getElementById("fileInput").click()}
-        className="border-2 border-dashed border-gray-400 w-full max-w-xl h-48 flex items-center justify-center cursor-pointer text-center"
-      >
-        Drag and drop a firmware file here or click to select
+    <div className="flex flex-col items-center justify-center flex-1 p-4">
+      <div className="w-full max-w-xl bg-white/80 backdrop-blur-sm rounded-xl shadow-lg p-6 text-center">
+        <h1 className="text-2xl mb-4 font-semibold">Upload Firmware</h1>
+        <div
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onClick={() => document.getElementById("fileInput").click()}
+          className="border-2 border-dashed border-gray-400 w-full h-48 flex items-center justify-center cursor-pointer rounded-lg bg-gray-50 hover:bg-gray-100 transition text-center"
+        >
+          Drag and drop a firmware file here or click to select
+        </div>
+        <input
+          id="fileInput"
+          type="file"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        {message && <p className="mt-4">{message}</p>}
       </div>
-      <input
-        id="fileInput"
-        type="file"
-        className="hidden"
-        onChange={handleFileChange}
-      />
-      {message && <p className="mt-4">{message}</p>}
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 @theme inline {
@@ -12,14 +12,8 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
+  background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,41 +20,6 @@
 }
 
 body {
-  background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
-}
-
-.container {
-  padding: 2rem;
-}
-
-@media (max-width: 640px) {
-  .container {
-    padding: 1rem;
-  }
-}
-
-.title {
-  text-align: center;
-  margin-bottom: 2rem;
-  font-size: 2rem;
-  font-weight: bold;
-}
-
-.chart-container {
-  position: relative;
-  margin: auto;
-  height: 60vh;
-  width: 80vw;
-}
-
-.dropdown-container {
-  text-align: center;
-  margin-bottom: 2rem;
-}
-
-.dropdown-container {
-  text-align: center;
-  margin-bottom: 2rem;
 }

--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -132,8 +132,8 @@ const GraphPage = () => {
   };
 
   return (
-    <div className="flex flex-col flex-1 p-4 sm:p-8">
-      <div className="bg-white/80 backdrop-blur-sm rounded-xl shadow-lg p-6 w-full">
+    <div className="flex flex-col flex-1 p-4 sm:p-8 text-gray-100">
+      <div className="bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-lg p-6 w-full">
         <h1 className="text-2xl font-semibold mb-4 text-center">Sensor Data</h1>
         <div className="flex justify-center mb-4">
           <select
@@ -270,7 +270,7 @@ const GraphPage = () => {
           </div>
         </div>
       ) : (
-        <p>Loading data...</p>
+        <p className="text-gray-300">Loading data...</p>
       )}
       </div>
     </div>

--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -132,34 +132,37 @@ const GraphPage = () => {
   };
 
   return (
-    <div className="container">
-      <h1 className="title text-xl sm:text-2xl">Sensor Data</h1>
-      <div className="dropdown-container flex justify-center">
-        <select
-          className="bg-black text-white p-2 rounded w-full max-w-xs"
-          onChange={(e) => setSelectedFile(e.target.value)}
-          value={selectedFile}
-        >
-          {filenames.map(file => (
-            <option key={file} value={file}>{file}</option>
-          ))}
-        </select>
-      </div>
-      <div className="w-full max-w-3xl mx-auto my-4">
-        <label className="flex flex-col items-center">
-          <span>Horizontal scale</span>
-          <input
-            type="range"
-            min={1}
-            max={voltageData?.labels.length || DEFAULT_SCALE}
-            value={scale}
-            onChange={(e) => setScale(Number(e.target.value))}
-            className="w-full"
-          />
-        </label>
-      </div>
-      {voltageData && currentData ? (
-        <div className="flex flex-col lg:flex-row w-full max-w-5xl mx-auto">
+    <div className="flex flex-col flex-1 p-4 sm:p-8">
+      <div className="bg-white/80 backdrop-blur-sm rounded-xl shadow-lg p-6 w-full">
+        <h1 className="text-2xl font-semibold mb-4 text-center">Sensor Data</h1>
+        <div className="flex justify-center mb-4">
+          <select
+            className="bg-gray-800 text-white p-2 rounded w-full max-w-xs"
+            onChange={(e) => setSelectedFile(e.target.value)}
+            value={selectedFile}
+          >
+            {filenames.map(file => (
+              <option key={file} value={file}>
+                {file}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="w-full max-w-3xl mx-auto my-4">
+          <label className="flex flex-col items-center">
+            <span>Horizontal scale</span>
+            <input
+              type="range"
+              min={1}
+              max={voltageData?.labels.length || DEFAULT_SCALE}
+              value={scale}
+              onChange={(e) => setScale(Number(e.target.value))}
+              className="w-full"
+            />
+          </label>
+        </div>
+        {voltageData && currentData ? (
+          <div className="flex flex-col lg:flex-row w-full max-w-5xl mx-auto">
           <div className="flex flex-col items-center space-y-8 flex-grow">
             <div className="w-full max-w-3xl">
               <h2 className="text-center mb-2">Voltage</h2>
@@ -269,6 +272,7 @@ const GraphPage = () => {
       ) : (
         <p>Loading data...</p>
       )}
+      </div>
     </div>
   );
 };

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -21,7 +21,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gradient-to-br from-gray-50 to-gray-200 text-gray-900 min-h-screen flex flex-col`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gradient-to-br from-gray-900 to-gray-800 text-gray-100 min-h-screen flex flex-col`}
       >
         <Navbar />
         {children}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -21,7 +21,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gradient-to-br from-gray-50 to-gray-200 text-gray-900 min-h-screen flex flex-col`}
       >
         <Navbar />
         {children}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -57,14 +57,14 @@ export default async function Home() {
         {fault && (
           <Link
             href={`/graph?file=${latestFile}`}
-            className="px-6 py-3 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors block sm:inline-block w-full sm:w-auto"
+            className="px-4 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 transition-colors block w-fit mx-auto"
           >
             View Latest Fault
           </Link>
         )}
         <Link
           href="/graph"
-          className="px-6 py-3 rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 transition-colors block sm:inline-block w-full sm:w-auto"
+          className="px-4 py-2 text-sm rounded-md bg-indigo-600 text-white hover:bg-indigo-500 transition-colors block w-fit mx-auto"
         >
           Go to Graph
         </Link>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -36,39 +36,39 @@ export default async function Home() {
   }
 
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-4 sm:p-8">
-      <h1 className="text-3xl sm:text-4xl font-bold mb-8 text-center">
-        Digital Fault Recorder
-      </h1>
-      {fault ? (
-        <div className="bg-gray-100 p-4 rounded w-full max-w-md mb-4 text-center space-y-1">
-          <p>
-            <strong>Fault Type:</strong> {formatLabel(fault.faultType)}
-          </p>
-          <p>
-            <strong>Date:</strong> {formatDate(fault.date)} {formatTime(fault.time)}
-          </p>
-          <p>
-            <strong>Location:</strong> {formatLabel(fault.faultLocation)}
-          </p>
-        </div>
-      ) : (
-        <p className="mb-4">No faults recorded.</p>
-      )}
-      {fault && (
+    <main className="flex flex-col items-center justify-center flex-1 p-4 sm:p-8">
+      <div className="w-full max-w-xl bg-white/80 backdrop-blur-sm rounded-xl shadow-lg p-6 text-center space-y-6">
+        <h1 className="text-3xl sm:text-4xl font-bold">Digital Fault Recorder</h1>
+        {fault ? (
+          <div className="bg-gray-50 p-4 rounded-lg shadow-inner space-y-1">
+            <p>
+              <strong>Fault Type:</strong> {formatLabel(fault.faultType)}
+            </p>
+            <p>
+              <strong>Date:</strong> {formatDate(fault.date)} {formatTime(fault.time)}
+            </p>
+            <p>
+              <strong>Location:</strong> {formatLabel(fault.faultLocation)}
+            </p>
+          </div>
+        ) : (
+          <p className="text-gray-700">No faults recorded.</p>
+        )}
+        {fault && (
+          <Link
+            href={`/graph?file=${latestFile}`}
+            className="px-6 py-3 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors block sm:inline-block w-full sm:w-auto"
+          >
+            View Latest Fault
+          </Link>
+        )}
         <Link
-          href={`/graph?file=${latestFile}`}
-          className="bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700 w-full sm:w-auto text-center mb-2"
+          href="/graph"
+          className="px-6 py-3 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-colors block sm:inline-block w-full sm:w-auto"
         >
-          View Latest Fault
+          Go to Graph
         </Link>
-      )}
-      <Link
-        href="/graph"
-        className="bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700 w-full sm:w-auto text-center"
-      >
-        Go to Graph
-      </Link>
+      </div>
     </main>
   );
 }

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -36,11 +36,11 @@ export default async function Home() {
   }
 
   return (
-    <main className="flex flex-col items-center justify-center flex-1 p-4 sm:p-8">
-      <div className="w-full max-w-xl bg-white/80 backdrop-blur-sm rounded-xl shadow-lg p-6 text-center space-y-6">
+    <main className="flex flex-col items-center justify-center flex-1 p-4 sm:p-8 text-gray-100">
+      <div className="w-full max-w-xl bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-lg p-6 text-center space-y-6">
         <h1 className="text-3xl sm:text-4xl font-bold">Digital Fault Recorder</h1>
         {fault ? (
-          <div className="bg-gray-50 p-4 rounded-lg shadow-inner space-y-1">
+          <div className="bg-gray-700 p-4 rounded-lg shadow-inner space-y-1">
             <p>
               <strong>Fault Type:</strong> {formatLabel(fault.faultType)}
             </p>
@@ -52,7 +52,7 @@ export default async function Home() {
             </p>
           </div>
         ) : (
-          <p className="text-gray-700">No faults recorded.</p>
+          <p className="text-gray-300">No faults recorded.</p>
         )}
         {fault && (
           <Link
@@ -64,7 +64,7 @@ export default async function Home() {
         )}
         <Link
           href="/graph"
-          className="px-6 py-3 rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 transition-colors block sm:inline-block w-full sm:w-auto"
+          className="px-6 py-3 rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 transition-colors block sm:inline-block w-full sm:w-auto"
         >
           Go to Graph
         </Link>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function Navbar() {
   return (
-    <nav className="bg-gradient-to-r from-blue-700 to-indigo-700 text-white shadow">
+    <nav className="bg-gradient-to-r from-gray-900 to-gray-800 text-white shadow">
       <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between py-4">
         <Link href="/" className="text-2xl font-semibold mb-2 sm:mb-0">
           DFR

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,18 +2,29 @@ import Link from "next/link";
 
 export default function Navbar() {
   return (
-    <nav className="bg-gray-800 text-white p-4">
-      <ul className="flex flex-col sm:flex-row gap-2 sm:gap-4 text-center sm:text-left">
-        <li>
-          <Link href="/" className="hover:underline">Home</Link>
-        </li>
-        <li>
-          <Link href="/graph" className="hover:underline">Graph</Link>
-        </li>
-        <li>
-          <Link href="/firmware" className="hover:underline">Firmware</Link>
-        </li>
-      </ul>
+    <nav className="bg-gradient-to-r from-blue-700 to-indigo-700 text-white shadow">
+      <div className="max-w-6xl mx-auto px-4 flex flex-col sm:flex-row items-center justify-between py-4">
+        <Link href="/" className="text-2xl font-semibold mb-2 sm:mb-0">
+          DFR
+        </Link>
+        <ul className="flex flex-col sm:flex-row gap-2 sm:gap-6 text-center sm:text-left">
+          <li>
+            <Link href="/" className="hover:text-gray-200 transition-colors">
+              Home
+            </Link>
+          </li>
+          <li>
+            <Link href="/graph" className="hover:text-gray-200 transition-colors">
+              Graph
+            </Link>
+          </li>
+          <li>
+            <Link href="/firmware" className="hover:text-gray-200 transition-colors">
+              Firmware
+            </Link>
+          </li>
+        </ul>
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- adopt gradient background and flex layout for full-height pages
- add branded gradient navbar and card-based page layouts
- simplify global CSS and refine graph and firmware pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b464c79f488327b86d589e6bb61d09