### PR TITLE
feat: add x-axis offset slider

### DIFF
--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -66,6 +66,17 @@ const GraphPage = () => {
     faultLocation: '',
   });
 
+  const maxOffset = Math.max(0, (voltageData?.labels.length || 0) - scale);
+
+  const adjustOffset = delta => {
+    setOffset(prev => {
+      const next = prev + delta;
+      if (next < 0) return 0;
+      if (next > maxOffset) return maxOffset;
+      return next;
+    });
+  };
+
   useEffect(() => {
     const fetchFilenames = async () => {
       try {
@@ -173,14 +184,30 @@ const GraphPage = () => {
         <div className="w-full max-w-3xl mx-auto my-4">
           <label className="flex flex-col items-center">
             <span>Horizontal offset</span>
-            <input
-              type="range"
-              min={0}
-              max={Math.max(0, (voltageData?.labels.length || 0) - scale)}
-              value={offset}
-              onChange={(e) => setOffset(Number(e.target.value))}
-              className="w-full"
-            />
+            <div className="flex items-center w-full gap-2">
+              <button
+                type="button"
+                onClick={() => adjustOffset(-1)}
+                className="px-2 py-1 bg-gray-700 rounded text-white"
+              >
+                -
+              </button>
+              <input
+                type="range"
+                min={0}
+                max={maxOffset}
+                value={offset}
+                onChange={(e) => setOffset(Number(e.target.value))}
+                className="flex-grow"
+              />
+              <button
+                type="button"
+                onClick={() => adjustOffset(1)}
+                className="px-2 py-1 bg-gray-700 rounded text-white"
+              >
+                +
+              </button>
+            </div>
           </label>
         </div>
         {voltageData && currentData ? (
@@ -196,6 +223,7 @@ const GraphPage = () => {
                     .map(ds => ({ ...ds, tension: 0.1, data: ds.data.slice(offset, offset + scale) })),
                 }}
                 options={{
+                  animation: false,
                   interaction: { mode: 'index', intersect: false },
                   plugins: { tooltip: { enabled: true } },
                   scales: {
@@ -238,6 +266,7 @@ const GraphPage = () => {
                     .map(ds => ({ ...ds, tension: 0.1, data: ds.data.slice(offset, offset + scale) })),
                 }}
                 options={{
+                  animation: false,
                   interaction: { mode: 'index', intersect: false },
                   plugins: { tooltip: { enabled: true } },
                   scales: {

--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Line } from 'react-chartjs-2';
 import {
@@ -76,6 +76,24 @@ const GraphPage = () => {
       return next;
     });
   };
+
+  const holdRef = useRef(null);
+
+  const startHoldAdjust = delta => {
+    adjustOffset(delta);
+    holdRef.current = setInterval(() => adjustOffset(delta), 150);
+  };
+
+  const stopHoldAdjust = () => {
+    if (holdRef.current) {
+      clearInterval(holdRef.current);
+      holdRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    return () => stopHoldAdjust();
+  }, []);
 
   useEffect(() => {
     const fetchFilenames = async () => {
@@ -187,7 +205,11 @@ const GraphPage = () => {
             <div className="flex items-center w-full gap-2">
               <button
                 type="button"
-                onClick={() => adjustOffset(-1)}
+                onMouseDown={() => startHoldAdjust(-1)}
+                onMouseUp={stopHoldAdjust}
+                onMouseLeave={stopHoldAdjust}
+                onTouchStart={() => startHoldAdjust(-1)}
+                onTouchEnd={stopHoldAdjust}
                 className="px-2 py-1 bg-gray-700 rounded text-white"
               >
                 -
@@ -202,7 +224,11 @@ const GraphPage = () => {
               />
               <button
                 type="button"
-                onClick={() => adjustOffset(1)}
+                onMouseDown={() => startHoldAdjust(1)}
+                onMouseUp={stopHoldAdjust}
+                onMouseLeave={stopHoldAdjust}
+                onTouchStart={() => startHoldAdjust(1)}
+                onTouchEnd={stopHoldAdjust}
                 className="px-2 py-1 bg-gray-700 rounded text-white"
               >
                 +


### PR DESCRIPTION
## Summary
- allow adjusting wave position with new horizontal offset slider
- slice voltage and current data based on offset
- keep offset within valid range when scale or data changes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b50d5eddc0832788088706ce4d5c39