### PR TITLE
Add endpoint for latest firmware download

### DIFF
--- a/src/app/api/firmware/latest/route.js
+++ b/src/app/api/firmware/latest/route.js
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { readdir, stat, readFile } from "fs/promises";
+import { join } from "path";
+
+export async function GET() {
+  try {
+    const firmwareDir = join(process.cwd(), "firmware");
+
+    let entries;
+    try {
+      entries = await readdir(firmwareDir, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === "ENOENT") {
+        return NextResponse.json(
+          { error: "No firmware found" },
+          { status: 404 }
+        );
+      }
+      throw err;
+    }
+
+    const files = entries.filter((e) => e.isFile());
+    if (files.length === 0) {
+      return NextResponse.json(
+        { error: "No firmware found" },
+        { status: 404 }
+      );
+    }
+
+    let latest = null;
+    let latestMtime = 0;
+    for (const file of files) {
+      const filePath = join(firmwareDir, file.name);
+      const { mtimeMs } = await stat(filePath);
+      if (mtimeMs > latestMtime) {
+        latestMtime = mtimeMs;
+        latest = file.name;
+      }
+    }
+
+    const buffer = await readFile(join(firmwareDir, latest));
+    return new NextResponse(buffer, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": `attachment; filename="${latest}"`,
+      },
+    });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to fetch most recently modified firmware file

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b55c21acf883279588cadce13a2d58