### PR TITLE
Document API endpoints and fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ A Next.js 15 application that stores JSON sensor data and renders it as interact
 4. **Upload firmware** from `/firmware` via drag-and-drop or file picker; files are stored under `firmware/` by `/api/firmware`.
 5. **See the latest fault summary** on the landing page with a quick link to its graph.
 
+## API Endpoints
+- `GET /api/data` – returns `{ success: true, filenames: [...] }`. Pass `?file=NAME` to receive `{ success: true, files: [content] }` for that file.
+- `POST /api/firmware` – accepts a multipart form with a `file` field and saves the upload to `firmware/`.
+- `GET /api/firmware/latest` – downloads the most recently uploaded firmware binary.
+
 ## Data Flow
 1. Data files are placed in `data/`.
 2. The client fetches `/api/data` to list files, then `/api/data?file=...` to get contents.
@@ -32,4 +37,3 @@ npm run dev      # start development server
 npm run lint     # run ESLint checks
 ```
 No test suite is currently defined.
-

--- a/agent.md
+++ b/agent.md
@@ -20,6 +20,11 @@ This project ingests JSON sensor data and visualizes it with Chart.js.
 3. The Graph page parses sample objects and renders them with `react-chartjs-2`.
 4. Firmware files are uploaded from `/firmware` and persisted by `/api/firmware`.
 
+## API Endpoints
+- `GET /api/data` – returns all filenames or, with `?file=name`, the contents of that file.
+- `POST /api/firmware` – accepts a form upload and writes the file to `firmware/`.
+- `GET /api/firmware/latest` – returns the most recently uploaded firmware binary.
+
 ## Development Notes
 - Uses Next.js 15, React 19, Tailwind CSS 4.
 - Run `npm run lint` before committing.

--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { Suspense, useEffect, useState, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Line } from 'react-chartjs-2';
 import {
@@ -42,7 +42,7 @@ const formatDate = dateStr => {
 
 const formatTime = timeStr => (timeStr ? timeStr.slice(0, 5) : '');
 
-const GraphPage = () => {
+const GraphContent = () => {
   const searchParams = useSearchParams();
   const fileParam = searchParams.get('file');
   const [voltageData, setVoltageData] = useState(null);
@@ -353,5 +353,11 @@ const GraphPage = () => {
     </div>
   );
 };
+
+const GraphPage = () => (
+  <Suspense fallback={<p className="text-gray-300">Loading...</p>}>
+    <GraphContent />
+  </Suspense>
+);
 
 export default GraphPage;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,16 +1,5 @@
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/components/Navbar";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata = {
   title: "Digital Fault Recorder",
@@ -20,9 +9,7 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gradient-to-br from-gray-900 to-gray-800 text-gray-100 min-h-screen flex flex-col`}
-      >
+      <body className="antialiased bg-gradient-to-br from-gray-900 to-gray-800 text-gray-100 min-h-screen flex flex-col">
         <Navbar />
         {children}
       </body>


### PR DESCRIPTION
## Summary
- remove external font imports and wrap search param usage in a Suspense boundary to restore Next.js build
- document data and firmware API endpoints, including latest firmware download

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b68ec062448327a523f180956bc010