### PR TITLE
Add A/B graph and sample data fields

### DIFF
--- a/send-dummy-data.sh
+++ b/send-dummy-data.sh
@@ -35,18 +35,21 @@ V3_FREQ=$(random_freq)
 I1_FREQ=$(random_freq)
 I2_FREQ=$(random_freq)
 I3_FREQ=$(random_freq)
+A_FREQ=$(random_freq)
+B_FREQ=$(random_freq)
 
 # Build JSON payload of sine wave samples
 JSON_PAYLOAD="{\"faultType\":\"$FAULT_TYPE\",\"faultLocation\":\"$FAULT_LOCATION\",\"date\":\"$CURRENT_DATE\",\"time\":\"$CURRENT_TIME\",\"data\":["
 for ((n = 0; n < SAMPLES; n++)); do
   VALUES=$(awk -v amp=$AMPLITUDE -v offset=$OFFSET -v n=$n \
-    -v f1=$V1_FREQ -v f2=$V2_FREQ -v f3=$V3_FREQ -v f4=$I1_FREQ -v f5=$I2_FREQ -v f6=$I3_FREQ \
+    -v f1=$V1_FREQ -v f2=$V2_FREQ -v f3=$V3_FREQ -v f4=$I1_FREQ -v f5=$I2_FREQ -v f6=$I3_FREQ -v f7=$A_FREQ -v f8=$B_FREQ \
     'BEGIN{t=n/1000; pi=3.14159265359; \
-      printf "%d %d %d %d %d %d", \
+      printf "%d %d %d %d %d %d %d %d", \
       int(amp*sin(2*pi*f1*t)+offset), int(amp*sin(2*pi*f2*t)+offset), int(amp*sin(2*pi*f3*t)+offset), \
-      int(amp*sin(2*pi*f4*t)+offset), int(amp*sin(2*pi*f5*t)+offset), int(amp*sin(2*pi*f6*t)+offset)}')
-  read v1 v2 v3 i1 i2 i3 <<<"$VALUES"
-  JSON_PAYLOAD+="{\"n\":$n,\"v1\":$v1,\"v2\":$v2,\"v3\":$v3,\"i1\":$i1,\"i2\":$i2,\"i3\":$i3},"
+      int(amp*sin(2*pi*f4*t)+offset), int(amp*sin(2*pi*f5*t)+offset), int(amp*sin(2*pi*f6*t)+offset), \
+      int(amp*sin(2*pi*f7*t)+offset), int(amp*sin(2*pi*f8*t)+offset)}')
+  read v1 v2 v3 i1 i2 i3 A B <<<"$VALUES"
+  JSON_PAYLOAD+="{\"n\":$n,\"v1\":$v1,\"v2\":$v2,\"v3\":$v3,\"i1\":$i1,\"i2\":$i2,\"i3\":$i3,\"A\":$A,\"B\":$B},"
 done
 JSON_PAYLOAD="${JSON_PAYLOAD%,}]}"
 
@@ -58,7 +61,7 @@ echo "---------------------------------"
 echo "Generating sine wave data:"
 echo "Fault Type: ${FAULT_TYPE}"
 echo "Fault Location: ${FAULT_LOCATION}"
-echo "Frequencies (Hz): v1=$V1_FREQ v2=$V2_FREQ v3=$V3_FREQ i1=$I1_FREQ i2=$I2_FREQ i3=$I3_FREQ"
+echo "Frequencies (Hz): v1=$V1_FREQ v2=$V2_FREQ v3=$V3_FREQ i1=$I1_FREQ i2=$I2_FREQ i3=$I3_FREQ A=$A_FREQ B=$B_FREQ"
 echo "Filename: $FILENAME"
 echo "---------------------------------"
 

--- a/src/app/graph/page.js
+++ b/src/app/graph/page.js
@@ -47,6 +47,7 @@ const GraphPage = () => {
   const fileParam = searchParams.get('file');
   const [voltageData, setVoltageData] = useState(null);
   const [currentData, setCurrentData] = useState(null);
+  const [abData, setAbData] = useState(null);
   const [filenames, setFilenames] = useState([]);
   const [selectedFile, setSelectedFile] = useState('');
   const [visible, setVisible] = useState({
@@ -56,6 +57,8 @@ const GraphPage = () => {
     i1: true,
     i2: true,
     i3: true,
+    A: true,
+    B: true,
   });
   const [scale, setScale] = useState(DEFAULT_SCALE);
   const [offset, setOffset] = useState(0);
@@ -141,14 +144,19 @@ const GraphPage = () => {
           { key: 'v2', label: 'V2', data: samples.map(p => p.v2), borderColor: 'green' },
           { key: 'v3', label: 'V3', data: samples.map(p => p.v3), borderColor: 'blue' },
         ].map(ds => ({ ...ds, min: Math.min(...ds.data), max: Math.max(...ds.data) }));
-        const currentDatasets = [
-          { key: 'i1', label: 'I1', data: samples.map(p => p.i1), borderColor: 'orange' },
-          { key: 'i2', label: 'I2', data: samples.map(p => p.i2), borderColor: 'purple' },
-          { key: 'i3', label: 'I3', data: samples.map(p => p.i3), borderColor: 'teal' },
-        ].map(ds => ({ ...ds, min: Math.min(...ds.data), max: Math.max(...ds.data) }));
+          const currentDatasets = [
+            { key: 'i1', label: 'I1', data: samples.map(p => p.i1), borderColor: 'orange' },
+            { key: 'i2', label: 'I2', data: samples.map(p => p.i2), borderColor: 'purple' },
+            { key: 'i3', label: 'I3', data: samples.map(p => p.i3), borderColor: 'teal' },
+          ].map(ds => ({ ...ds, min: Math.min(...ds.data), max: Math.max(...ds.data) }));
+          const abDatasets = [
+            { key: 'A', label: 'A', data: samples.map(p => p.A), borderColor: 'yellow' },
+            { key: 'B', label: 'B', data: samples.map(p => p.B), borderColor: 'pink' },
+          ].map(ds => ({ ...ds, min: Math.min(...ds.data), max: Math.max(...ds.data) }));
 
-        setVoltageData({ labels, datasets: voltageDatasets });
-        setCurrentData({ labels, datasets: currentDatasets });
+          setVoltageData({ labels, datasets: voltageDatasets });
+          setCurrentData({ labels, datasets: currentDatasets });
+          setAbData({ labels, datasets: abDatasets });
         setScale(Math.min(labels.length, DEFAULT_SCALE));
         setOffset(0);
       } catch (error) {
@@ -236,7 +244,7 @@ const GraphPage = () => {
             </div>
           </label>
         </div>
-        {voltageData && currentData ? (
+        {voltageData && currentData && abData ? (
           <div className="flex flex-col lg:flex-row w-full max-w-5xl mx-auto">
           <div className="flex flex-col items-center space-y-8 flex-grow">
             <div className="w-full max-w-3xl">
@@ -282,50 +290,93 @@ const GraphPage = () => {
                 ))}
               </div>
             </div>
-            <div className="w-full max-w-3xl">
-              <h2 className="text-center mb-2">Current</h2>
-              <Line
-                data={{
-                  labels: currentData.labels.slice(offset, offset + scale),
-                  datasets: currentData.datasets
-                    .filter(ds => visible[ds.key])
-                    .map(ds => ({ ...ds, tension: 0.1, data: ds.data.slice(offset, offset + scale) })),
-                }}
-                options={{
-                  animation: false,
-                  interaction: { mode: 'index', intersect: false },
-                  plugins: { tooltip: { enabled: true } },
-                  scales: {
-                    y: {
-                      title: {
-                        display: true,
-                        text: 'Current [A]'
+              <div className="w-full max-w-3xl">
+                <h2 className="text-center mb-2">Current</h2>
+                <Line
+                  data={{
+                    labels: currentData.labels.slice(offset, offset + scale),
+                    datasets: currentData.datasets
+                      .filter(ds => visible[ds.key])
+                      .map(ds => ({ ...ds, tension: 0.1, data: ds.data.slice(offset, offset + scale) })),
+                  }}
+                  options={{
+                    animation: false,
+                    interaction: { mode: 'index', intersect: false },
+                    plugins: { tooltip: { enabled: true } },
+                    scales: {
+                      y: {
+                        title: {
+                          display: true,
+                          text: 'Current [A]'
+                        }
                       }
                     }
-                  }
-                }}
-              />
-              <div className="flex justify-center gap-4 mt-2">
-                {['i1', 'i2', 'i3'].map(key => (
-                  <label key={key} className="flex items-center gap-1">
-                    <input
-                      type="checkbox"
-                      checked={visible[key]}
-                      onChange={() => toggleVisibility(key)}
-                    />
-                    {key.toUpperCase()}
-                  </label>
-                ))}
+                  }}
+                />
+                <div className="flex justify-center gap-4 mt-2">
+                  {['i1', 'i2', 'i3'].map(key => (
+                    <label key={key} className="flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={visible[key]}
+                        onChange={() => toggleVisibility(key)}
+                      />
+                      {key.toUpperCase()}
+                    </label>
+                  ))}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs mt-2 text-center">
+                  {currentData.datasets.map(ds => (
+                    <div key={ds.key}>
+                      {ds.label} Min: {ds.min.toFixed(2)} Max: {ds.max.toFixed(2)}
+                    </div>
+                  ))}
+                </div>
               </div>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs mt-2 text-center">
-                {currentData.datasets.map(ds => (
-                  <div key={ds.key}>
-                    {ds.label} Min: {ds.min.toFixed(2)} Max: {ds.max.toFixed(2)}
-                  </div>
-                ))}
+              <div className="w-full max-w-3xl">
+                <h2 className="text-center mb-2">A & B</h2>
+                <Line
+                  data={{
+                    labels: abData.labels.slice(offset, offset + scale),
+                    datasets: abData.datasets
+                      .filter(ds => visible[ds.key])
+                      .map(ds => ({ ...ds, tension: 0.1, data: ds.data.slice(offset, offset + scale) })),
+                  }}
+                  options={{
+                    animation: false,
+                    interaction: { mode: 'index', intersect: false },
+                    plugins: { tooltip: { enabled: true } },
+                    scales: {
+                      y: {
+                        title: {
+                          display: true,
+                          text: 'A/B'
+                        }
+                      }
+                    }
+                  }}
+                />
+                <div className="flex justify-center gap-4 mt-2">
+                  {['A', 'B'].map(key => (
+                    <label key={key} className="flex items-center gap-1">
+                      <input
+                        type="checkbox"
+                        checked={visible[key]}
+                        onChange={() => toggleVisibility(key)}
+                      />
+                      {key.toUpperCase()}
+                    </label>
+                  ))}
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs mt-2 text-center">
+                  {abData.datasets.map(ds => (
+                    <div key={ds.key}>
+                      {ds.label} Min: {ds.min.toFixed(2)} Max: {ds.max.toFixed(2)}
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
           <div className="w-full lg:w-64 lg:ml-4 mt-8 lg:mt-0">
             <h2 className="mb-2 font-semibold">Fault Info</h2>
             <p>


### PR DESCRIPTION
## Summary
- Add A/B datasets and chart on graph page
- Extend dummy data script to generate A and B values

## Testing
- `npm run lint`
- `./send-dummy-data.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b925b04df083278f8b9c5a70163498