### PR TITLE
Restrict firmware uploads to .bin files

### DIFF
--- a/src/app/firmware/page.jsx
+++ b/src/app/firmware/page.jsx
@@ -22,14 +22,24 @@ export default function FirmwarePage() {
   const handleDrop = (e) => {
     e.preventDefault();
     const file = e.dataTransfer.files[0];
-    if (file) uploadFile(file);
+    if (!file) return;
+    if (!file.name.endsWith(".bin")) {
+      setMessage("Only .bin files are allowed");
+      return;
+    }
+    uploadFile(file);
   };
 
   const handleDragOver = (e) => e.preventDefault();
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];
-    if (file) uploadFile(file);
+    if (!file) return;
+    if (!file.name.endsWith(".bin")) {
+      setMessage("Only .bin files are allowed");
+      return;
+    }
+    uploadFile(file);
   };
 
   return (
@@ -44,9 +54,11 @@ export default function FirmwarePage() {
         >
           Drag and drop a firmware file here or click to select
         </div>
+        <p className="mt-2 text-sm text-yellow-400">Please upload only .bin files.</p>
         <input
           id="fileInput"
           type="file"
+          accept=".bin"
           className="hidden"
           onChange={handleFileChange}
         />


### PR DESCRIPTION
## Summary
- Limit firmware uploader to `.bin` files only
- Warn users that only `.bin` files are permitted

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b94c401ef083279355c723de3c503a