### PR TITLE
Add About page and update navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Next.js 15 application that stores JSON sensor data and renders it as interact
 - **API Routes**: Located in `src/app/api/`, they handle data retrieval and firmware uploads.
 - **Data Storage**: Files are saved under the top-level `data/` folder.
 - **Firmware Storage**: Uploaded binaries are written to the top-level `firmware/` folder.
-- **Client Components**: Pages under `src/app/` fetch lists of JSON files and plot selected datasets via `react-chartjs-2`. A reusable `Navbar` component links to Home, Graph, and Firmware pages.
+- **Client Components**: Pages under `src/app/` fetch lists of JSON files and plot selected datasets via `react-chartjs-2`. A reusable `Navbar` component links to Home, Graph, Firmware, and About pages.
 
 ## Core Features
 1. **Generate JSON files** (e.g., via `send-dummy-data.sh`) directly into `data/`.
@@ -15,6 +15,7 @@ A Next.js 15 application that stores JSON sensor data and renders it as interact
 3. **Visualize data** on the Graph page where users choose a file and see its waveform samples on dual voltage/current charts.
 4. **Upload firmware** from `/firmware` via drag-and-drop or file picker; files are stored under `firmware/` by `/api/firmware`.
 5. **See the latest fault summary** on the landing page with a quick link to its graph.
+6. **Learn about the project** on the `/about` page.
 
 ## API Endpoints
 - `GET /api/data` – returns `{ success: true, filenames: [...] }`. Pass `?file=NAME` to receive `{ success: true, files: [content] }` for that file.

--- a/agent.md
+++ b/agent.md
@@ -7,10 +7,11 @@ This project ingests JSON sensor data and visualizes it with Chart.js.
   - `page.js` – landing page displaying the latest fault summary.
   - `graph/page.js` – client page that lists JSON files and draws charts.
   - `firmware/page.jsx` – drag-and-drop interface for uploading firmware files.
+  - `about/page.jsx` – static page describing the project.
   - `api/data/route.js` – lists filenames or returns file contents based on the `file` query string.
   - `api/firmware/route.js` – saves uploaded firmware to the top-level `firmware/` directory.
   - `data/` – runtime storage for JSON files.
-- `src/components/Navbar.jsx` – links to Home, Graph, and Firmware pages.
+  - `src/components/Navbar.jsx` – links to Home, Graph, Firmware, and About pages.
 - `send-dummy-data.sh` – helper script to generate synthetic JSON for testing.
 - `firmware/` – storage for uploaded firmware binaries.
 

--- a/src/app/about/page.jsx
+++ b/src/app/about/page.jsx
@@ -1,0 +1,13 @@
+export default function AboutPage() {
+  return (
+    <div className="flex flex-col items-center justify-center flex-1 p-4 text-gray-100">
+      <div className="w-full max-w-xl bg-gray-800/80 backdrop-blur-sm rounded-xl shadow-lg p-6 text-center space-y-4">
+        <h1 className="text-2xl font-semibold">About Me</h1>
+        <p>
+          This project visualizes digital fault recorder data and demonstrates a simple
+          Next.js app with Tailwind CSS and Chart.js.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -23,6 +23,11 @@ export default function Navbar() {
               Firmware
             </Link>
           </li>
+          <li>
+            <Link href="/about" className="hover:text-gray-200 transition-colors">
+              About
+            </Link>
+          </li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- add static About page
- link About page from Navbar
- document About page in README and agent guide

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbed25e998832782494c319bb58608