### PR TITLE
Ensure firmware download response headers

### DIFF
--- a/src/app/api/firmware/latest/route.js
+++ b/src/app/api/firmware/latest/route.js
@@ -38,12 +38,17 @@ export async function GET() {
       }
     }
 
-    const buffer = await readFile(join(firmwareDir, latest));
-    return new NextResponse(buffer, {
+    const fileBuffer = await readFile(join(firmwareDir, latest));
+    const fileSize = fileBuffer.length;
+
+    return new NextResponse(fileBuffer, {
       status: 200,
       headers: {
         "Content-Type": "application/octet-stream",
         "Content-Disposition": `attachment; filename="${latest}"`,
+        "Content-Length": fileSize.toString(),
+        "Content-Encoding": "identity",
+        "Cache-Control": "no-store, no-transform",
       },
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure the firmware download endpoint sets explicit headers for binary payloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64886f3f08327a2a085b09b9caa1c